### PR TITLE
Feat: Add new reusable UI components and flatten structure

### DIFF
--- a/touchui-evo/CHANGELOG.md
+++ b/touchui-evo/CHANGELOG.md
@@ -1,3 +1,25 @@
+### Update <YYYY-MM-DD> (Please replace with actual date)
+
+**Feat: Add new reusable UI components**
+
+Added the following new reusable components to `touchui-evo/src/components/`:
+
+*Data Display Components:*
+- **CircularGauge:** SVG-based semi-circle gauge for values like temperature.
+- **StatusIndicatorLight:** Pill/circle-shaped indicator with color changes and pulsing animation for status.
+- **DataCard:** Specialized `TouchUICard` for displaying a key-value pair with an icon.
+
+*Control Components:*
+- **ControlSlider:** Compact MUI Slider wrapper with icon, label, and live value.
+- **ToggleCard:** `TouchUICard` with an icon, label, and MUI Switch for On/Off actions.
+- **FileListItem:** Component for file browser rows with icon, name, metadata, and placeholder for touch gesture support.
+
+**Refactor: Flatten component file structure**
+
+- Refactored the file structure for the new components (`CircularGauge`, `StatusIndicatorLight`, `DataCard`, `ControlSlider`, `ToggleCard`, `FileListItem`) to be flat within the `touchui-evo/src/components/` directory, removing individual subfolders for each. Component files (e.g., `CircularGauge.tsx`) are now directly under `src/components/`.
+
+---
+
 ### Stato Attuale e Prossimi Passi
 
 Il lavoro iniziale di setup e configurazione è stato completato con successo, nonostante alcune difficoltà con l'ambiente di esecuzione dei test, che sono state temporaneamente aggirate per procedere con lo sviluppo.

--- a/touchui-evo/src/components/CircularGauge.tsx
+++ b/touchui-evo/src/components/CircularGauge.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Box, Typography, useTheme } from '@mui/material';
+
+interface CircularGaugeProps {
+  value: number;
+  minValue?: number;
+  maxValue?: number;
+  size?: number;
+  strokeWidth?: number;
+  label?: string;
+  unit?: string;
+  valueFontSize?: string | number;
+  labelFontSize?: string | number;
+}
+
+const CircularGauge: React.FC<CircularGaugeProps> = ({
+  value,
+  minValue = 0,
+  maxValue = 100,
+  size = 200,
+  strokeWidth = 16,
+  label,
+  unit = '',
+  valueFontSize = '2.5rem',
+  labelFontSize = '1rem',
+}) => {
+  const theme = useTheme();
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * Math.PI; // Semi-circle
+
+  const percentage = Math.max(0, Math.min(100, ((value - minValue) / (maxValue - minValue)) * 100));
+  const offset = circumference - (percentage / 100) * circumference;
+
+  const viewBox = `0 0 ${size} ${size / 2 + strokeWidth / 2}`;
+
+  const primaryColor = theme.palette.primary.main;
+  const trackColor = theme.palette.custom?.componentBorder || theme.palette.grey[700];
+  const textColor = theme.palette.text.primary;
+
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size / 2 + strokeWidth / 2 + 40, // Adjusted for text below
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'flex-start', // Align SVG to top
+      }}
+    >
+      <svg
+        width={size}
+        height={size / 2 + strokeWidth / 2}
+        viewBox={viewBox}
+        style={{ transform: 'rotateX(180deg) rotateZ(180deg)', overflow: 'visible' }}
+      >
+        <path
+          d={`M ${strokeWidth / 2} ${size / 2}
+              A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2}`}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+        <path
+          d={`M ${strokeWidth / 2} ${size / 2}
+              A ${radius} ${radius} 0 0 1 ${size - strokeWidth / 2} ${size / 2}`}
+          fill="none"
+          stroke={primaryColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          style={{ transition: 'stroke-dashoffset 0.3s ease' }}
+        />
+      </svg>
+      <Box
+        sx={{
+          position: 'absolute',
+          bottom: 0, // Position text at the very bottom of the main Box
+          width: '100%',
+          textAlign: 'center',
+          color: textColor,
+        }}
+      >
+        <Typography
+          variant="h3"
+          component="div"
+          sx={{
+            fontWeight: 'bold',
+            fontSize: valueFontSize,
+            lineHeight: 1.1,
+            color: primaryColor, // Make value color primary
+          }}
+        >
+          {value.toFixed(1)}{unit}
+        </Typography>
+        {label && (
+          <Typography
+            variant="caption"
+            component="div"
+            sx={{
+              fontSize: labelFontSize,
+              color: theme.palette.text.secondary,
+              marginTop: '4px',
+            }}
+          >
+            {label}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default CircularGauge;

--- a/touchui-evo/src/components/ControlSlider.tsx
+++ b/touchui-evo/src/components/ControlSlider.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { Box, Typography, Slider, Grid, useTheme, SxProps, Theme } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+// Custom styled Slider for Neumorphic/Glassmorphism look if needed,
+// or rely on global MUI Slider theme overrides.
+// For now, we'll use the standard MUI Slider and assume it's themed globally.
+const StyledSlider = styled(Slider)(({ theme }) => ({
+  // Example of custom styling for the slider track and thumb to match the glass/neumorphic theme
+  // This can be expanded based on specific design requirements.
+  // color: theme.palette.primary.main, // Already default
+  // '& .MuiSlider-thumb': {
+  //   backgroundColor: theme.palette.primary.main,
+  //   border: `2px solid ${theme.palette.common.white}`,
+  //   '&:hover, &.Mui-focusVisible': {
+  //     boxShadow: `0 0 0 8px ${theme.palette.primary.main}33`, // Faint glow
+  //   },
+  //   '&.Mui-active': {
+  //     boxShadow: `0 0 0 14px ${theme.palette.primary.main}55`, // Stronger glow when active
+  //   },
+  // },
+  // '& .MuiSlider-track': {
+  //   height: 6,
+  // },
+  // '& .MuiSlider-rail': {
+  //   height: 6,
+  //   backgroundColor: theme.palette.custom?.componentBorder || theme.palette.grey[700],
+  // },
+}));
+
+interface ControlSliderProps {
+  icon?: React.ReactNode;
+  label: string;
+  value: number;
+  onChange: (event: Event, newValue: number | number[]) => void;
+  onChangeCommitted?: (event: React.SyntheticEvent | Event, newValue: number | number[]) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  disabled?: boolean;
+  sx?: SxProps<Theme>;
+  iconSx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
+  valueSx?: SxProps<Theme>;
+}
+
+const ControlSlider: React.FC<ControlSliderProps> = ({
+  icon,
+  label,
+  value,
+  onChange,
+  onChangeCommitted,
+  min = 0,
+  max = 100,
+  step = 1,
+  unit = '%',
+  disabled = false,
+  sx,
+  iconSx,
+  labelSx,
+  valueSx,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Box sx={{ padding: theme.spacing(1.5, 2), ...sx }}>
+      <Grid container spacing={2} alignItems="center">
+        {icon && (
+          <Grid item sx={{ color: theme.palette.text.secondary, ...iconSx }}>
+            {icon}
+          </Grid>
+        )}
+        <Grid item xs>
+          <Typography
+            variant="body2"
+            id={`control-slider-label-${label.toLowerCase().replace(/\s+/g, '-')}`}
+            gutterBottom
+            sx={{ color: theme.palette.text.secondary, userSelect: 'none', ...labelSx }}
+          >
+            {label}
+          </Typography>
+          <StyledSlider
+            value={value}
+            onChange={onChange}
+            onChangeCommitted={onChangeCommitted}
+            aria-labelledby={`control-slider-label-${label.toLowerCase().replace(/\s+/g, '-')}`}
+            min={min}
+            max={max}
+            step={step}
+            disabled={disabled}
+            valueLabelDisplay="auto" // Consider if value label on thumb is desired
+          />
+        </Grid>
+        <Grid item sx={{ minWidth: '50px', textAlign: 'right' }}>
+          <Typography
+            variant="body1"
+            sx={{ fontWeight: 'bold', color: theme.palette.primary.main, userSelect: 'none', ...valueSx }}
+          >
+            {value.toFixed(step && step < 1 ? 1 : 0)}{unit}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default ControlSlider;

--- a/touchui-evo/src/components/DataCard.tsx
+++ b/touchui-evo/src/components/DataCard.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Box, Typography, useTheme, SxProps, Theme } from '@mui/material';
+import { TouchUiCard, TouchUiCardProps } from '../TouchUiCard'; // Assuming TouchUiCardProps are exported
+
+interface DataCardProps extends Omit<TouchUiCardProps, 'children'> {
+  icon?: React.ReactNode;
+  label: string;
+  value: string | number;
+  variant?: 'normal' | 'highlight';
+  sx?: SxProps<Theme>;
+  iconSx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
+  valueSx?: SxProps<Theme>;
+}
+
+const DataCard: React.FC<DataCardProps> = ({
+  icon,
+  label,
+  value,
+  variant = 'normal',
+  sx,
+  iconSx,
+  labelSx,
+  valueSx,
+  ...touchUiCardProps
+}) => {
+  const theme = useTheme();
+  const highlightColor = theme.palette.primary.main;
+
+  return (
+    <TouchUiCard
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: theme.spacing(2),
+        minHeight: '120px', // Ensure a consistent minimum size
+        ...sx,
+      }}
+      {...touchUiCardProps}
+    >
+      {icon && (
+        <Box
+          component="div"
+          sx={{
+            marginBottom: 1,
+            color: variant === 'highlight' ? highlightColor : theme.palette.text.secondary,
+            fontSize: '2rem', // Default icon size
+            ...iconSx,
+          }}
+        >
+          {icon}
+        </Box>
+      )}
+      <Typography
+        variant="caption"
+        component="div"
+        sx={{
+          color: theme.palette.text.secondary,
+          marginBottom: 0.5,
+          ...labelSx,
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        variant="h5"
+        component="div"
+        sx={{
+          fontWeight: 'bold',
+          color: variant === 'highlight' ? highlightColor : theme.palette.text.primary,
+          ...valueSx,
+        }}
+      >
+        {value}
+      </Typography>
+    </TouchUiCard>
+  );
+};
+
+export default DataCard;

--- a/touchui-evo/src/components/FileListItem.tsx
+++ b/touchui-evo/src/components/FileListItem.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { Box, Typography, IconButton, useTheme, SxProps, Theme, Paper } from '@mui/material';
+// Icons for actions, replace with actual icons from the project's library
+// import MoreVertIcon from '@mui/icons-material/MoreVert';
+// import DeleteIcon from '@mui/icons-material/Delete';
+// import PrintIcon from '@mui/icons-material/Print';
+
+interface FileMetadata {
+  key: string;
+  value: string | number;
+}
+
+interface FileListItemProps {
+  icon: React.ReactNode; // e.g., an SVG icon component for file type
+  name: string;
+  metadata?: FileMetadata[]; // e.g., [{key: "Size", value: "12.3 MB"}, {key: "Date", value: "2023-10-26"}]
+  onClick?: () => void;
+  onSwipeLeft?: () => void; // Placeholder for swipe action
+  onSwipeRight?: () => void; // Placeholder for swipe action
+  sx?: SxProps<Theme>;
+  actions?: React.ReactNode[]; // For explicit action buttons if swipe is not the only interaction
+}
+
+// Basic styling for the swipe action hints / areas (optional)
+const swipeActionBaseStyles: SxProps<Theme> = {
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  width: '70px', // Width of the revealed action area
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: 'white',
+  transition: 'transform 0.3s ease, opacity 0.3s ease',
+  opacity: 0, // Hidden by default
+  zIndex: 0,
+};
+
+const FileListItem: React.FC<FileListItemProps> = ({
+  icon,
+  name,
+  metadata = [],
+  onClick,
+  onSwipeLeft,
+  onSwipeRight,
+  sx,
+  actions,
+}) => {
+  const theme = useTheme();
+  // State for swipe interaction (if implementing without a library initially)
+  // const [offsetX, setOffsetX] = React.useState(0);
+  // const [revealedAction, setRevealedAction] = React.useState<'left' | 'right' | null>(null);
+
+  // Placeholder for touch handling logic
+  // This would involve onTouchStart, onTouchMove, onTouchEnd
+  // and calculating distances/velocities to trigger swipe actions.
+  // For a real implementation, a library like react-swipeable is recommended.
+
+  const handleItemClick = () => {
+    // Logic to prevent click if a swipe was intended might be needed here
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  return (
+    <Paper
+      elevation={0} // Use Paper for background and potential border, but keep it flat unless TouchUiCard is intended
+      sx={{
+        position: 'relative', // For swipe action overlays
+        display: 'flex',
+        alignItems: 'center',
+        padding: theme.spacing(1.5, 2),
+        backgroundColor: theme.palette.background.paper, // Or custom card background from theme
+        borderBottom: `1px solid ${theme.palette.custom?.componentBorder || theme.palette.divider}`,
+        cursor: onClick ? 'pointer' : 'default',
+        overflow: 'hidden', // Important for swipe effect where actions are revealed from sides
+        '&:last-child': {
+          borderBottom: 'none',
+        },
+        // Add hover effect if desired, e.g.
+        // '&:hover': {
+        //   backgroundColor: onClick ? theme.palette.action.hover : 'transparent',
+        // },
+        ...sx,
+      }}
+      onClick={handleItemClick}
+      // Add touch event handlers here if not using a library
+    >
+      {/* Background for Swipe Right Action (e.g., Print) */}
+      {onSwipeRight && (
+        <Box sx={{
+          ...swipeActionBaseStyles,
+          left: 0,
+          // transform: revealedAction === 'right' ? 'translateX(0)' : 'translateX(-100%)',
+          // opacity: revealedAction === 'right' ? 1 : 0,
+          backgroundColor: theme.palette.success.main, // Example color
+        }}>
+          {/* <PrintIcon /> Placeholder */}
+        </Box>
+      )}
+
+      {/* Background for Swipe Left Action (e.g., Delete) */}
+      {onSwipeLeft && (
+        <Box sx={{
+          ...swipeActionBaseStyles,
+          right: 0,
+          // transform: revealedAction === 'left' ? 'translateX(0)' : 'translateX(100%)',
+          // opacity: revealedAction === 'left' ? 1 : 0,
+          backgroundColor: theme.palette.error.main, // Example color
+        }}>
+          {/* <DeleteIcon /> Placeholder */}
+        </Box>
+      )}
+
+      {/* Main content, slides with swipe */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          flexGrow: 1,
+          // transform: `translateX(${offsetX}px)`, // Apply swipe offset
+          transition: 'transform 0.3s ease', // Smooth transition back if swipe is not completed
+          backgroundColor: theme.palette.background.paper, // Ensure content background is opaque
+          zIndex: 1, // Above swipe action backgrounds
+        }}
+      >
+        <Box
+          component="div"
+          sx={{
+            marginRight: 2,
+            color: theme.palette.primary.main, // Icon color
+            display: 'flex',
+            alignItems: 'center',
+            fontSize: '1.8rem', // Larger icon for touch
+          }}
+        >
+          {icon}
+        </Box>
+        <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+          <Typography
+            variant="body1"
+            noWrap
+            sx={{ fontWeight: 500, color: theme.palette.text.primary }}
+          >
+            {name}
+          </Typography>
+          {metadata.length > 0 && (
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing(0.5, 2) }}>
+              {metadata.map((item) => (
+                <Typography
+                  key={item.key}
+                  variant="caption"
+                  noWrap
+                  sx={{ color: theme.palette.text.secondary }}
+                >
+                  {item.key}: {item.value}
+                </Typography>
+              ))}
+            </Box>
+          )}
+        </Box>
+        {actions && (
+          <Box sx={{ display: 'flex', alignItems: 'center', marginLeft: 1, zIndex: 2 /* Ensure actions are clickable */ }}>
+            {actions.map((action, index) => (
+              <React.Fragment key={index}>{action}</React.Fragment>
+            ))}
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default FileListItem;

--- a/touchui-evo/src/components/StatusIndicatorLight.tsx
+++ b/touchui-evo/src/components/StatusIndicatorLight.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Box, useTheme } from '@mui/material';
+import { keyframes } from '@mui/system';
+
+export type StatusType = 'success' | 'warning' | 'error' | 'neutral' | 'connecting';
+
+interface StatusIndicatorLightProps {
+  status: StatusType;
+  shape?: 'circle' | 'pill';
+  pulsing?: boolean;
+  size?: number; // For circle: diameter; for pill: height
+}
+
+const pulseAnimation = keyframes`
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+`;
+
+const StatusIndicatorLight: React.FC<StatusIndicatorLightProps> = ({
+  status,
+  shape = 'circle',
+  pulsing = false,
+  size = 12,
+}) => {
+  const theme = useTheme();
+
+  const statusColors: Record<StatusType, string | undefined> = {
+    success: theme.palette.custom?.statusSuccess,
+    warning: theme.palette.custom?.statusWarning,
+    error: theme.palette.custom?.statusError,
+    neutral: theme.palette.custom?.statusNeutral,
+    connecting: theme.palette.custom?.statusConnecting,
+  };
+
+  const backgroundColor = statusColors[status] || theme.palette.custom?.statusNeutral || theme.palette.grey[500];
+
+  const baseStyles = {
+    width: shape === 'pill' ? size * 2.5 : size,
+    height: size,
+    backgroundColor,
+    borderRadius: shape === 'pill' ? size / 2 : '50%',
+    display: 'inline-block',
+    transition: 'background-color 0.3s ease',
+  };
+
+  const pulsingStyles = pulsing
+    ? {
+        animation: `${pulseAnimation} 1.5s infinite ease-in-out`,
+        boxShadow: `0 0 ${size / 2}px ${backgroundColor}`, // Add a glow effect when pulsing
+      }
+    : {};
+
+  return <Box sx={{ ...baseStyles, ...pulsingStyles }} />;
+};
+
+export default StatusIndicatorLight;

--- a/touchui-evo/src/components/ToggleCard.tsx
+++ b/touchui-evo/src/components/ToggleCard.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { Box, Typography, Switch, useTheme, SxProps, Theme } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { TouchUiCard, TouchUiCardProps } from '../TouchUiCard'; // Assuming TouchUiCard is at this path
+
+// Custom styled Switch for Neumorphic/Glassmorphism look if needed
+// For now, we'll use the standard MUI Switch and assume it's themed globally or via props.
+// Theming for Switch can be quite detailed.
+const StyledSwitch = styled(Switch)(({ theme }) => ({
+  // Example: Customizing the switch track and thumb
+  // padding: 8,
+  // '& .MuiSwitch-track': {
+  //   borderRadius: 22 / 2,
+  //   backgroundColor: theme.palette.mode === 'light' ? theme.palette.grey[300] : theme.palette.grey[700],
+  //   opacity: 1,
+  //   transition: theme.transitions.create(['background-color'], {
+  //     duration: 500,
+  //   }),
+  // },
+  // '& .MuiSwitch-thumb': {
+  //   boxShadow: 'none',
+  //   backgroundColor: theme.palette.common.white,
+  //   width: 16,
+  //   height: 16,
+  //   margin: 2,
+  // },
+  // '& .Mui-checked': {
+  //   transform: 'translateX(16px)', // Adjust based on switch size
+  //   '& + .MuiSwitch-track': {
+  //     backgroundColor: theme.palette.primary.main,
+  //     opacity: 1,
+  //   },
+  //   '& .MuiSwitch-thumb': {
+  //     backgroundColor: theme.palette.common.white,
+  //   }
+  // },
+}));
+
+interface ToggleCardProps extends Omit<TouchUiCardProps, 'children' | 'onClick'> {
+  icon?: React.ReactNode;
+  label: string;
+  checked: boolean;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
+  disabled?: boolean;
+  sx?: SxProps<Theme>;
+  iconSx?: SxProps<Theme>;
+  labelSx?: SxProps<Theme>;
+}
+
+const ToggleCard: React.FC<ToggleCardProps> = ({
+  icon,
+  label,
+  checked,
+  onChange,
+  disabled = false,
+  sx,
+  iconSx,
+  labelSx,
+  ...touchUiCardProps
+}) => {
+  const theme = useTheme();
+
+  return (
+    <TouchUiCard
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: theme.spacing(1.5, 2), // Consistent padding
+        cursor: disabled ? 'default' : 'pointer',
+        ...sx,
+      }}
+      onClick={!disabled ? (e) => onChange(e as any, !checked) : undefined} // Allow clicking card to toggle
+      {...touchUiCardProps}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, marginRight: 2 }}>
+        {icon && (
+          <Box
+            component="div"
+            sx={{
+              marginRight: 1.5,
+              color: checked ? theme.palette.primary.main : theme.palette.text.secondary,
+              display: 'flex',
+              alignItems: 'center',
+              ...iconSx,
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Typography
+          variant="body1"
+          sx={{
+            fontWeight: 500,
+            color: checked ? theme.palette.text.primary : theme.palette.text.secondary,
+            userSelect: 'none',
+            ...labelSx,
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
+      <StyledSwitch
+        checked={checked}
+        onChange={onChange}
+        disabled={disabled}
+        onClick={(e) => e.stopPropagation()} // Prevent card click handler from firing twice
+      />
+    </TouchUiCard>
+  );
+};
+
+export default ToggleCard;

--- a/touchui-evo/src/components/index.ts
+++ b/touchui-evo/src/components/index.ts
@@ -1,4 +1,10 @@
 // This file will re-export all components for cleaner imports.
 export * from './TouchUiCard';
 export * from './TouchUiButton';
+export * from './CircularGauge';
+export * from './StatusIndicatorLight';
+export * from './DataCard';
+export * from './ControlSlider';
+export * from './ToggleCard';
+export * from './FileListItem';
 // Example: export * from './MyComponent';


### PR DESCRIPTION
Added the following new reusable components to touchui-evo/src/components/:

Data Display Components:
- CircularGauge: SVG-based semi-circle gauge for values like temperature.
- StatusIndicatorLight: Pill/circle-shaped indicator with color changes and pulsing animation for status.
- DataCard: Specialized TouchUICard for displaying a key-value pair with an icon.

Control Components:
- ControlSlider: Compact MUI Slider wrapper with icon, label, and live value.
- ToggleCard: TouchUICard with an icon, label, and MUI Switch for On/Off actions.
- FileListItem: Component for file browser rows with icon, name, metadata, and placeholder for touch gesture support.

Refactored the file structure for these components to be flat within the `touchui-evo/src/components/` directory, removing individual subfolders. Updated `CHANGELOG.md` accordingly.